### PR TITLE
Use First CCI reference

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -101,7 +101,7 @@ if (files.length === 0) {
                         vulnerabilities = vulnerabilities.concat(iSTIG.VULN.map((vulnerability) => {
                             const values = {};
                             // Extract STIG_DATA
-                            vulnerability.STIG_DATA.forEach((data) => {
+                            vulnerability.STIG_DATA.reverse().forEach((data) => {
                                 values[data.VULN_ATTRIBUTE[0]] = data.ATTRIBUTE_DATA[0]
                             });
                             // Extract remaining fields (status, finding deails, comments, security override, and severity justification)


### PR DESCRIPTION
Closes #4, uses first CCI reference to map to NIST control (CCI/NIST mappings updated in [a192b3e13d1b644bcc8872bd85b2f0cf1bc3c0eb](https://github.com/mitre/ckl2POAM/commit/a192b3e13d1b644bcc8872bd85b2f0cf1bc3c0eb))

Fixes #4 