### PR TITLE
Add Source Identifying Vulnerability from STIG Info

### DIFF
--- a/settings.json
+++ b/settings.json
@@ -6,6 +6,7 @@
         "securityChecks": "F",
         "resourcesRequired": "G",
         "scheduledCompletionDate": "H",
+        "sourceIdentifyingVulnerability": "K",
         "status": "L",
         "comments": "M",
         "rawSeverity": "N",

--- a/src/convertStrings.ts
+++ b/src/convertStrings.ts
@@ -152,7 +152,7 @@ export function cci2nist(cci: string) {
         if (cci in cci2nistmap) {
             return cci2nistmap[cci].replace(' ', '')
         } else {
-            return prompt(`What is the NIST ID for CCI ${cci}? `)
+            return prompt(`What is the NIST Control for CCI ${cci}? `)
         }
     } else {
         return "UM-1"

--- a/src/index.ts
+++ b/src/index.ts
@@ -69,7 +69,7 @@ if (files.length === 0) {
                         message: `An error occoured parsing the file: ${readFileError}`
                     })
                 } else {
-                    let infos: {title?: string, stigid?: string} = {};
+                    let infos: {[key: string]: string} = {};
                     let vulnerabilities: STIG.Vulnerability[] = []
                     const iStigs: STIG.iSTIG[] = []
                     const stigs = result.CHECKLIST.STIGS
@@ -146,6 +146,8 @@ if (files.length === 0) {
                                 // Scheduled Completion Date
                                 // Default is one year from today
                                 sheet.cell(`${settings.rows.scheduledCompletionDate}${currentRow}`).value(aYearFromNow)
+                                // Source Identifying Vulnerability
+                                sheet.cell(`${settings.rows.sourceIdentifyingVulnerability}${currentRow}`).value(`Identified by ${infos.title} :: Version ${infos.version}, ${infos.releaseinfo}`)
                                 // Status
                                 sheet.cell(`${settings.rows.status}${currentRow}`).value(cleanStatus(vulnerability.STATUS))
                                 // Comments


### PR DESCRIPTION
Closes #11, adds Source Identifying Vulnerability based off the format `Identified by ${STIG Title} :: Version ${STIG Version}, ${STIG Release Info}`